### PR TITLE
Fix `Dockerfile` using recent node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:current-alpine
+FROM node:18-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
- We were using `node:current-alpine` image to build the docker image, but somehow a recent update break up the Next.js image build so I'm returning to an older node version.